### PR TITLE
Add rate limiting and refactor candlestick data handling

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,5 +23,6 @@
     <PackageVersion Include="Selenium.WebDriver" Version="4.33.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <PackageVersion Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="9.0.6" />
   </ItemGroup>
 </Project>

--- a/src/CandlestickDownloader/Candlestick.cs
+++ b/src/CandlestickDownloader/Candlestick.cs
@@ -1,0 +1,11 @@
+﻿namespace CandlestickDownloader;
+
+public class Candlestick
+{
+    public required double Open { get; init; }
+    public required double High { get; init; }
+    public required double Low { get; init; }
+    public required double Close { get; init; }
+    public required long Volume { get; init; }
+    public required long DateTime { get; init; }
+}

--- a/src/CandlestickDownloader/CandlestickDownloader.csproj
+++ b/src/CandlestickDownloader/CandlestickDownloader.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" />
+    <PackageReference Include="System.Threading.RateLimiting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CandlestickDownloader/CandlestickDownloaderOptions.cs
+++ b/src/CandlestickDownloader/CandlestickDownloaderOptions.cs
@@ -1,13 +1,6 @@
 ﻿namespace CandlestickDownloader;
 public sealed record class CandlestickDownloaderOptions
 {
-    public required string Symbols { get; init; }
-    public required string PeriodType { get; init; }
-    public required int Period { get; init; }
-    public required string FrequencyType { get; init; }
-    public required int Frequency { get; init; }
-    public required long StartDate { get; init; }
-    public required long EndDate { get; init; }
-    public required bool NeedExtendedData { get; init; }
-    public required bool NeedPreviousClose { get; init; }
+    public required List<string> Symbols { get; init; }
+    public required string DataFolder { get; init; }
 }

--- a/src/CandlestickDownloader/CandlestickHistory.cs
+++ b/src/CandlestickDownloader/CandlestickHistory.cs
@@ -1,0 +1,7 @@
+﻿namespace CandlestickDownloader;
+internal class CandlestickHistory
+{
+    public required string Symbol { get; init; }
+    public required bool Empty { get; init; }
+    public required List<Candlestick> Candles { get; init; } = new List<Candlestick>();
+}

--- a/src/CandlestickDownloader/Program.cs
+++ b/src/CandlestickDownloader/Program.cs
@@ -1,8 +1,11 @@
 ﻿using System.CommandLine;
+using System.Text.Json;
+using System.Threading.RateLimiting;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 using TraderAPI;
@@ -12,6 +15,22 @@ namespace CandlestickDownloader;
 
 internal class Program
 {
+    private static ILogger s_logger = NullLogger<Program>.Instance;
+    private static readonly RateLimiter RateLimiter = new TokenBucketRateLimiter(
+        new TokenBucketRateLimiterOptions
+        {
+            TokenLimit = 10,
+            QueueLimit = int.MaxValue,
+            AutoReplenishment = true,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(0.5),
+            TokensPerPeriod = 1
+        });
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     static async Task<int> Main(string[] args)
     {
         Option<string> configFileOption = new("--config-file")
@@ -64,22 +83,113 @@ internal class Program
             .BindConfiguration(nameof(CandlestickDownloaderOptions));
 
         ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        s_logger = serviceProvider.GetRequiredService<ILogger<Program>>();
+
         CancellationTokenSource cancellationTokenSource = serviceProvider.GetRequiredService<CancellationTokenSource>();
         CandlestickDownloaderOptions options = serviceProvider.GetRequiredService<IOptions<CandlestickDownloaderOptions>>().Value;
         Client client = serviceProvider.GetRequiredService<Client>();
-        
-        HttpResponseMessage data = await client.PriceHistoryAsync(
-             options.Symbols,
-             options.PeriodType,
-             options.Period,
-             options.FrequencyType,
-             options.Frequency,
-             options.StartDate,
-             options.EndDate,
-             options.NeedExtendedData,
-             options.NeedPreviousClose,
-             cancellationTokenSource.Token);
 
-        data.EnsureSuccessStatusCode();
+        s_logger.LogInformation("Starting Candlestick Downloader...");
+
+
+
+        foreach (string symbol in options.Symbols)
+        {
+            int deltaDays = 0;
+
+            while (true)
+            {
+                long startDate = GetNewYorkOpenUnixMillis(-1 * deltaDays);
+                long endDate = startDate + 12 * 60 * 60 * 1000;
+                deltaDays++;
+
+                if (IsWeekend(startDate))
+                {
+                    s_logger.LogInformation("Skipping weekend date: {StartDate}", DateTimeOffset.FromUnixTimeMilliseconds(startDate));
+                    continue;
+                }
+
+                RateLimitLease lease = await RateLimiter.AcquireAsync(1, cancellationTokenSource.Token);
+                while (!lease.IsAcquired)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationTokenSource.Token);
+                    lease?.Dispose();
+                    lease = await RateLimiter.AcquireAsync(1, cancellationTokenSource.Token);
+                }
+                lease.Dispose();
+
+
+                HttpResponseMessage data = await client.PriceHistoryAsync(
+                        symbol,
+                        "day",
+                        1,
+                        "minute",
+                        1,
+                        startDate,
+                        endDate,
+                        false,
+                        false,
+                        cancellationTokenSource.Token);
+
+                if (data.IsSuccessStatusCode)
+                {
+                    s_logger.LogInformation("Successfully retrieved data for {Symbol} on {StartDate}", symbol, DateTimeOffset.FromUnixTimeMilliseconds(startDate));
+                    string responseContent = await data.Content.ReadAsStringAsync(cancellationTokenSource.Token);
+
+                    CandlestickHistory? history = JsonSerializer.Deserialize<CandlestickHistory>(responseContent, JsonSerializerOptions);
+                    if (history is null || history.Empty)
+                    {
+                        s_logger.LogWarning("No data found for {Symbol} on {StartDate}", symbol, DateTimeOffset.FromUnixTimeMilliseconds(startDate));
+                        break;
+                    }
+
+                    WriteData(responseContent, options.DataFolder, symbol, startDate);
+                }
+                else
+                {
+                    s_logger.LogError("Failed to retrieve data for {Symbol} on {StartDate}: {StatusCode} - {ReasonPhrase}", symbol, DateTimeOffset.FromUnixTimeMilliseconds(startDate), data.StatusCode, data.ReasonPhrase);
+                }
+            }
+        }
+
+        s_logger.LogInformation("Candlestick Downloader completed successfully.");
+    }
+
+    private static void WriteData(string responseContent, string dataFolder, string symbol, long startDate)
+    {
+
+
+        DateTime date = DateTimeOffset.FromUnixTimeMilliseconds(startDate).UtcDateTime;
+        string year = date.Year.ToString("D4");
+        string month = date.Month.ToString("D2");
+        string day = date.Day.ToString("D2");
+        string path = Path.Combine(dataFolder, symbol.ToUpperInvariant(), year, month);
+        string fileName = $"{symbol}-{year}-{month}-{day}.json";
+        string finalPath = Path.Combine(path, fileName);
+
+        Directory.CreateDirectory(path);
+        File.WriteAllText(finalPath, responseContent);
+
+        s_logger.LogInformation("Response content saved to {FilePath}", finalPath);
+    }
+
+    private static long GetNewYorkOpenUnixMillis(int deltaDays)
+    {
+        TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        DateTime nowEastern = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, easternZone);
+        DateTime deltaTime = nowEastern.Add(TimeSpan.FromDays(deltaDays));
+        DateTime openEastern = new(deltaTime.Year, deltaTime.Month, deltaTime.Day, 6, 30, 0, DateTimeKind.Unspecified);
+        DateTime openEasternUtc = TimeZoneInfo.ConvertTimeToUtc(openEastern, easternZone);
+        long unixMillis = new DateTimeOffset(openEasternUtc).ToUnixTimeMilliseconds();
+        return unixMillis;
+    }
+
+    private static bool IsWeekend(long unixMillis)
+    {
+        DateTime dateTime = DateTimeOffset.FromUnixTimeMilliseconds(unixMillis).DateTime;
+        TimeZoneInfo easternZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        DateTime easternTime = TimeZoneInfo.ConvertTimeFromUtc(dateTime, easternZone);
+        return easternTime.DayOfWeek == DayOfWeek.Saturday || easternTime.DayOfWeek == DayOfWeek.Sunday;
     }
 }


### PR DESCRIPTION
- Updated `Directory.Packages.props` and `CandlestickDownloader.csproj` to include `System.Threading.RateLimiting`.
- Refactored `CandlestickDownloaderOptions.cs` to simplify properties, replacing multiple required fields with a list of symbols and a data folder path.
- Enhanced `Program.cs` to implement a rate limiter, add logging, and manage candlestick data retrieval in a loop.
- Introduced `Candlestick` and `CandlestickHistory` classes to represent individual candlestick data and collections, respectively.