### PR TITLE
Add data validation for history.Candles count

### DIFF
--- a/src/CandlestickDownloader/Program.cs
+++ b/src/CandlestickDownloader/Program.cs
@@ -144,6 +144,12 @@ internal class Program
                         break;
                     }
 
+                    if(history.Candles.Count <= 1)
+                    {
+                        s_logger.LogWarning("Insufficient data for {Symbol} on {StartDate}: {Count} candle(s) found", symbol, DateTimeOffset.FromUnixTimeMilliseconds(startDate), history.Candles.Count);
+                        continue;
+                    }
+
                     WriteData(responseContent, options.DataFolder, symbol, startDate);
                 }
                 else


### PR DESCRIPTION
Implement a check to ensure that the `history.Candles` collection contains more than one candle before processing. If the count is insufficient, log a warning and skip to the next iteration. This enhances error handling and prevents processing of inadequate data.